### PR TITLE
feat: add daily database backup scheduler using AioClock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__
 # Secrets - never commit
 secrets.env
 *.env.local
+
+# Backups
+backups/

--- a/README.md
+++ b/README.md
@@ -25,12 +25,20 @@ Create a `secrets.env` file with the required credentials (see `docs/infrastruct
 ADMIDIO_DB_NAME=admidio
 ADMIDIO_DB_USER=admidio
 ADMIDIO_DB_PASSWORD=<password>
+ADMIDIO_DB_ROOT_PASSWORD=<root_password>
 ADMIDIO_TABLE_PREFIX=adm_
 
 # Hetzner SSH Access
 HETZNER_SSH_HOST=<ip>
 HETZNER_SSH_USER=root
 HETZNER_SSH_KEY_PATH=~/.ssh/hetzner_key
+
+# Backup Configuration (optional)
+BACKUP_DIR=./backups
+BACKUP_RETENTION_DAYS=30
+BACKUP_TIME_HOUR=2
+BACKUP_TIME_MINUTE=0
+BACKUP_TIMEZONE=Europe/Berlin
 ```
 
 ## Pipelines
@@ -68,14 +76,54 @@ uv run spendenquittungen
 
 **Output:** `data/Spendenquittungen_{year}.xlsx`
 
+### Database Backup
+
+Automated daily backups of the Admidio MariaDB database.
+
+```bash
+# Run backup scheduler (continuous, backs up at 2 AM Europe/Berlin)
+uv run backup-scheduler
+
+# Run single backup immediately
+uv run backup-scheduler --once
+```
+
+**Features:**
+- Daily automated backups at 02:00 Europe/Berlin
+- Compressed with gzip (~130KB per backup)
+- Automatic retention cleanup (default: 30 days)
+- Runs as systemd user service
+
+**Backup location:** `backups/admidio_YYYYMMDD_HHMMSS.sql.gz`
+
+#### Systemd Service
+
+The backup scheduler runs as a systemd user service:
+
+```bash
+# Check status
+systemctl --user status st-andreas-backup
+
+# View logs
+journalctl --user -u st-andreas-backup -f
+
+# Restart service
+systemctl --user restart st-andreas-backup
+```
+
 ## Project Structure
 
 ```
 src/st_andreas/
 ├── __init__.py
-├── admidio_db.py       # Shared database utilities (SSH tunnel, queries)
-├── fetch_members.py    # Mitgliederliste pipeline
-└── spendenquittungen.py # Spendenquittungen pipeline
+├── admidio_db.py         # Shared database utilities (SSH tunnel, queries)
+├── fetch_members.py      # Mitgliederliste pipeline
+├── spendenquittungen.py  # Spendenquittungen pipeline
+└── backup/
+    ├── config.py         # Backup configuration
+    ├── dump.py           # Database dump operations
+    ├── retention.py      # Backup retention cleanup
+    └── scheduler.py      # AioClock scheduler
 ```
 
 ## Testing

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -110,3 +110,56 @@ sshpass -p '<password>' ssh administrator@10.10.10.18
 2. SSH keys should have `600` permissions
 3. Rotate passwords periodically
 4. Restrict phpMyAdmin access if possible (currently on public port)
+
+---
+
+## Database Backups
+
+### Overview
+
+Automated daily backups run at 02:00 Europe/Berlin time. Backups are stored locally in the `backups/` directory and compressed with gzip.
+
+### Configuration
+
+Optional settings in `secrets.env`:
+
+```bash
+BACKUP_DIR=./backups           # Default: ./backups
+BACKUP_RETENTION_DAYS=30       # Default: 30
+BACKUP_TIME_HOUR=2             # Default: 2 (2 AM)
+BACKUP_TIME_MINUTE=0           # Default: 0
+BACKUP_TIMEZONE=Europe/Berlin  # Default: Europe/Berlin
+```
+
+### Running the Backup Scheduler
+
+```bash
+# Start scheduler (runs continuously, executes backup at scheduled time)
+uv run backup-scheduler
+
+# Run single backup immediately (for testing)
+uv run backup-scheduler --once
+```
+
+### Manual Backup via SSH
+
+```bash
+ssh -i ~/.ssh/hetzner_key root@91.98.90.85 \
+  "docker exec admidio_db mysqldump -u root -p<password> admidio" \
+  | gzip > backups/admidio_manual_$(date +%Y%m%d_%H%M%S).sql.gz
+```
+
+### Restoring from Backup
+
+```bash
+# Decompress and restore
+gunzip -c backups/admidio_20250401_020000.sql.gz | \
+  ssh -i ~/.ssh/hetzner_key root@91.98.90.85 \
+  "docker exec -i admidio_db mysql -u root -p<password> admidio"
+```
+
+### Backup Files
+
+- **Location:** `backups/` directory (gitignored)
+- **Naming:** `admidio_YYYYMMDD_HHMMSS.sql.gz`
+- **Retention:** Configurable, default 30 days

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 description = "St. Andreas data pipelines and tools"
 requires-python = ">=3.11"
 dependencies = [
+    "aioclock>=0.1",
     "openpyxl>=3.0",
     "pandas>=2.0",
     "pymysql>=1.1",
@@ -14,9 +15,11 @@ dev = [
     "dirty-equals>=0.7",
     "inline-snapshot>=0.10",
     "pytest>=8.0",
+    "pytest-asyncio>=0.23",
 ]
 
 [project.scripts]
+backup-scheduler = "st_andreas.backup.scheduler:main"
 fetch-members = "st_andreas.fetch_members:main"
 spendenquittungen = "st_andreas.spendenquittungen:main"
 

--- a/src/st_andreas/backup/__init__.py
+++ b/src/st_andreas/backup/__init__.py
@@ -1,0 +1,1 @@
+"""Database backup utilities for Admidio."""

--- a/src/st_andreas/backup/config.py
+++ b/src/st_andreas/backup/config.py
@@ -1,0 +1,59 @@
+"""Backup configuration types and loaders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from st_andreas.admidio_db import load_secrets
+
+DEFAULT_BACKUP_DIR: Final = Path(__file__).parent.parent.parent.parent / "backups"
+DEFAULT_RETENTION_DAYS: Final = 30
+DEFAULT_SCHEDULE_HOUR: Final = 2
+DEFAULT_SCHEDULE_MINUTE: Final = 0
+DEFAULT_TIMEZONE: Final = "Europe/Berlin"
+
+DOCKER_CONTAINER_NAME: Final = "admidio_db"
+MYSQLDUMP_DATABASE: Final = "admidio"
+
+
+@dataclass
+class BackupConfig:
+    """Configuration for database backups."""
+
+    backup_dir: Path
+    retention_days: int
+    schedule_hour: int
+    schedule_minute: int
+    timezone: str
+    db_root_password: str
+
+
+def load_backup_config(secrets: dict[str, str] | None = None) -> BackupConfig:
+    """Load backup configuration from secrets and defaults."""
+    if secrets is None:
+        secrets = load_secrets()
+
+    backup_dir_str = secrets.get("BACKUP_DIR")
+    backup_dir = Path(backup_dir_str) if backup_dir_str else DEFAULT_BACKUP_DIR
+
+    retention_str = secrets.get("BACKUP_RETENTION_DAYS")
+    retention_days = int(retention_str) if retention_str else DEFAULT_RETENTION_DAYS
+
+    hour_str = secrets.get("BACKUP_TIME_HOUR")
+    schedule_hour = int(hour_str) if hour_str else DEFAULT_SCHEDULE_HOUR
+
+    minute_str = secrets.get("BACKUP_TIME_MINUTE")
+    schedule_minute = int(minute_str) if minute_str else DEFAULT_SCHEDULE_MINUTE
+
+    timezone = secrets.get("BACKUP_TIMEZONE", DEFAULT_TIMEZONE)
+
+    return BackupConfig(
+        backup_dir=backup_dir,
+        retention_days=retention_days,
+        schedule_hour=schedule_hour,
+        schedule_minute=schedule_minute,
+        timezone=timezone,
+        db_root_password=secrets["ADMIDIO_DB_ROOT_PASSWORD"],
+    )

--- a/src/st_andreas/backup/dump.py
+++ b/src/st_andreas/backup/dump.py
@@ -1,0 +1,112 @@
+"""Database dump operations via SSH."""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from st_andreas.admidio_db import SSHConfig
+from st_andreas.backup.config import DOCKER_CONTAINER_NAME, MYSQLDUMP_DATABASE
+
+if TYPE_CHECKING:
+    from st_andreas.backup.config import BackupConfig
+
+
+class BackupError(Exception):
+    """Raised when backup operation fails."""
+
+
+def build_backup_filename(timestamp: datetime) -> str:
+    """Generate backup filename with timestamp."""
+    formatted = timestamp.strftime("%Y%m%d_%H%M%S")
+    return f"admidio_{formatted}.sql.gz"
+
+
+def build_ssh_command(ssh_config: SSHConfig) -> list[str]:
+    """Build SSH command prefix for remote execution."""
+    expanded_key_path = Path(ssh_config.key_path).expanduser()
+    return [
+        "ssh",
+        "-i",
+        str(expanded_key_path),
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "BatchMode=yes",
+        f"{ssh_config.user}@{ssh_config.host}",
+    ]
+
+
+def build_mysqldump_command(db_root_password: str) -> str:
+    """Build mysqldump command to run inside Docker container."""
+    return (
+        f"docker exec {DOCKER_CONTAINER_NAME} "
+        f"mysqldump -u root -p{db_root_password} {MYSQLDUMP_DATABASE}"
+    )
+
+
+async def create_backup(
+    ssh_config: SSHConfig,
+    backup_config: BackupConfig,
+    timestamp: datetime | None = None,
+) -> Path:
+    """Execute mysqldump via SSH and save compressed backup locally.
+
+    Streams mysqldump output through SSH and compresses with gzip.
+    """
+    if timestamp is None:
+        timestamp = datetime.now()
+
+    backup_config.backup_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = build_backup_filename(timestamp)
+    backup_path = backup_config.backup_dir / filename
+
+    ssh_cmd = build_ssh_command(ssh_config)
+    mysqldump_cmd = build_mysqldump_command(backup_config.db_root_password)
+    full_command = [*ssh_cmd, mysqldump_cmd]
+
+    process = await asyncio.create_subprocess_exec(
+        *full_command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stdout, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        error_msg = stderr.decode().strip() if stderr else "Unknown error"
+        raise BackupError(f"mysqldump failed: {error_msg}")
+
+    if not stdout:
+        raise BackupError("mysqldump returned empty output")
+
+    with gzip.open(backup_path, "wb") as f:
+        f.write(stdout)
+
+    verify_backup(backup_path)
+
+    return backup_path
+
+
+def verify_backup(backup_path: Path) -> None:
+    """Verify backup file is valid gzip with content."""
+    if not backup_path.exists():
+        raise BackupError(f"Backup file not created: {backup_path}")
+
+    if backup_path.stat().st_size == 0:
+        backup_path.unlink()
+        raise BackupError("Backup file is empty")
+
+    try:
+        with gzip.open(backup_path, "rb") as f:
+            header = f.read(100)
+            if not header:
+                backup_path.unlink()
+                raise BackupError("Backup file contains no data after decompression")
+    except gzip.BadGzipFile as e:
+        backup_path.unlink()
+        raise BackupError(f"Invalid gzip file: {e}") from e

--- a/src/st_andreas/backup/retention.py
+++ b/src/st_andreas/backup/retention.py
@@ -1,0 +1,41 @@
+"""Backup retention and cleanup operations."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def find_expired_backups(backup_dir: Path, retention_days: int) -> list[Path]:
+    """Find backup files older than retention period."""
+    if not backup_dir.exists():
+        return []
+
+    cutoff = datetime.now() - timedelta(days=retention_days)
+    expired: list[Path] = []
+
+    for backup_file in backup_dir.glob("admidio_*.sql.gz"):
+        file_mtime = datetime.fromtimestamp(backup_file.stat().st_mtime)
+        if file_mtime < cutoff:
+            expired.append(backup_file)
+
+    return expired
+
+
+def cleanup_old_backups(backup_dir: Path, retention_days: int) -> list[Path]:
+    """Delete backups older than retention period, return deleted paths."""
+    expired = find_expired_backups(backup_dir, retention_days)
+    deleted: list[Path] = []
+
+    for backup_file in expired:
+        try:
+            backup_file.unlink()
+            deleted.append(backup_file)
+            log.info("Deleted expired backup: %s", backup_file.name)
+        except OSError:
+            log.exception("Failed to delete backup: %s", backup_file.name)
+
+    return deleted

--- a/src/st_andreas/backup/scheduler.py
+++ b/src/st_andreas/backup/scheduler.py
@@ -1,0 +1,108 @@
+"""AioClock scheduler for daily database backups."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Final
+
+from aioclock import AioClock, At, Once
+
+from st_andreas.admidio_db import SSHConfig, load_secrets, load_ssh_config
+from st_andreas.backup.config import BackupConfig, load_backup_config
+from st_andreas.backup.dump import BackupError, create_backup
+from st_andreas.backup.retention import cleanup_old_backups
+
+log = logging.getLogger(__name__)
+
+LOG_FORMAT: Final = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+
+def setup_logging() -> None:
+    """Configure logging for the backup scheduler."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format=LOG_FORMAT,
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+
+@asynccontextmanager
+async def lifespan(app: AioClock) -> AsyncGenerator[AioClock]:
+    """Scheduler lifecycle management."""
+    log.info("Backup scheduler starting")
+    yield app
+    log.info("Backup scheduler shutting down")
+
+
+def create_scheduler(
+    backup_config: BackupConfig,
+    ssh_config: SSHConfig,
+    once: bool = False,
+) -> AioClock:
+    """Create and configure the AioClock scheduler."""
+    app = AioClock(lifespan=lifespan)
+
+    if once:
+        trigger = Once()
+    else:
+        trigger = At(
+            tz=backup_config.timezone,
+            hour=backup_config.schedule_hour,
+            minute=backup_config.schedule_minute,
+            second=0,
+        )
+
+    @app.task(trigger=trigger)
+    async def daily_backup() -> None:
+        """Execute daily database backup and cleanup."""
+        log.info("Starting scheduled backup")
+
+        try:
+            backup_path = await create_backup(ssh_config, backup_config)
+            log.info("Backup completed: %s", backup_path.name)
+        except BackupError:
+            log.exception("Backup failed")
+            return
+
+        deleted = cleanup_old_backups(
+            backup_config.backup_dir,
+            backup_config.retention_days,
+        )
+        if deleted:
+            log.info("Cleaned up %d expired backup(s)", len(deleted))
+
+    return app
+
+
+def main() -> None:
+    """Entry point for backup scheduler CLI."""
+    setup_logging()
+
+    once = "--once" in sys.argv
+
+    secrets = load_secrets()
+    backup_config = load_backup_config(secrets)
+    ssh_config = load_ssh_config(secrets)
+
+    log.info(
+        "Backup scheduled for %02d:%02d %s",
+        backup_config.schedule_hour,
+        backup_config.schedule_minute,
+        backup_config.timezone,
+    )
+    log.info("Backup directory: %s", backup_config.backup_dir)
+    log.info("Retention: %d days", backup_config.retention_days)
+
+    if once:
+        log.info("Running in one-shot mode")
+
+    app = create_scheduler(backup_config, ssh_config, once=once)
+    asyncio.run(app.serve())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backup_config.py
+++ b/tests/test_backup_config.py
@@ -1,0 +1,44 @@
+"""Tests for backup configuration."""
+
+from pathlib import Path
+
+from st_andreas.backup.config import (
+    DEFAULT_BACKUP_DIR,
+    DEFAULT_RETENTION_DAYS,
+    DEFAULT_SCHEDULE_HOUR,
+    DEFAULT_SCHEDULE_MINUTE,
+    DEFAULT_TIMEZONE,
+    load_backup_config,
+)
+
+
+class TestLoadBackupConfig:
+    def test_uses_defaults_when_not_specified(self) -> None:
+        secrets = {"ADMIDIO_DB_ROOT_PASSWORD": "test_password"}
+
+        config = load_backup_config(secrets)
+
+        assert config.backup_dir == DEFAULT_BACKUP_DIR
+        assert config.retention_days == DEFAULT_RETENTION_DAYS
+        assert config.schedule_hour == DEFAULT_SCHEDULE_HOUR
+        assert config.schedule_minute == DEFAULT_SCHEDULE_MINUTE
+        assert config.timezone == DEFAULT_TIMEZONE
+
+    def test_loads_custom_values_from_secrets(self) -> None:
+        secrets = {
+            "ADMIDIO_DB_ROOT_PASSWORD": "secret123",
+            "BACKUP_DIR": "/custom/backups",
+            "BACKUP_RETENTION_DAYS": "7",
+            "BACKUP_TIME_HOUR": "4",
+            "BACKUP_TIME_MINUTE": "30",
+            "BACKUP_TIMEZONE": "UTC",
+        }
+
+        config = load_backup_config(secrets)
+
+        assert config.backup_dir == Path("/custom/backups")
+        assert config.retention_days == 7
+        assert config.schedule_hour == 4
+        assert config.schedule_minute == 30
+        assert config.timezone == "UTC"
+        assert config.db_root_password == "secret123"

--- a/tests/test_backup_dump.py
+++ b/tests/test_backup_dump.py
@@ -1,0 +1,165 @@
+"""Tests for backup dump operations."""
+
+import gzip
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from st_andreas.admidio_db import SSHConfig
+from st_andreas.backup.config import BackupConfig
+from st_andreas.backup.dump import (
+    BackupError,
+    build_backup_filename,
+    build_mysqldump_command,
+    build_ssh_command,
+    create_backup,
+    verify_backup,
+)
+
+
+class TestBuildBackupFilename:
+    def test_formats_timestamp_correctly(self) -> None:
+        timestamp = datetime(2025, 4, 1, 2, 30, 45)
+
+        result = build_backup_filename(timestamp)
+
+        assert result == "admidio_20250401_023045.sql.gz"
+
+
+class TestBuildSshCommand:
+    def test_builds_correct_command(self) -> None:
+        config = SSHConfig(
+            host="192.168.1.1",
+            user="admin",
+            key_path="~/.ssh/test_key",
+        )
+
+        result = build_ssh_command(config)
+
+        assert result[0] == "ssh"
+        assert "-i" in result
+        assert "StrictHostKeyChecking=no" in result
+        assert "BatchMode=yes" in result
+        assert "admin@192.168.1.1" in result
+
+
+class TestBuildMysqldumpCommand:
+    def test_builds_correct_command(self) -> None:
+        result = build_mysqldump_command("secret123")
+
+        assert "docker exec admidio_db" in result
+        assert "mysqldump" in result
+        assert "-u root" in result
+        assert "-psecret123" in result
+        assert "admidio" in result
+
+
+class TestVerifyBackup:
+    def test_raises_when_file_missing(self, tmp_path: Path) -> None:
+        nonexistent = tmp_path / "missing.sql.gz"
+
+        with pytest.raises(BackupError, match="not created"):
+            verify_backup(nonexistent)
+
+    def test_raises_and_deletes_empty_file(self, tmp_path: Path) -> None:
+        empty_file = tmp_path / "empty.sql.gz"
+        empty_file.touch()
+
+        with pytest.raises(BackupError, match="empty"):
+            verify_backup(empty_file)
+
+        assert not empty_file.exists()
+
+    def test_raises_and_deletes_invalid_gzip(self, tmp_path: Path) -> None:
+        invalid_file = tmp_path / "invalid.sql.gz"
+        invalid_file.write_bytes(b"not gzip content")
+
+        with pytest.raises(BackupError, match="Invalid gzip"):
+            verify_backup(invalid_file)
+
+        assert not invalid_file.exists()
+
+    def test_accepts_valid_gzip_with_content(self, tmp_path: Path) -> None:
+        valid_file = tmp_path / "valid.sql.gz"
+        with gzip.open(valid_file, "wb") as f:
+            f.write(b"CREATE TABLE test;")
+
+        verify_backup(valid_file)
+
+        assert valid_file.exists()
+
+
+class TestCreateBackup:
+    @pytest.fixture
+    def ssh_config(self) -> SSHConfig:
+        return SSHConfig(
+            host="test.example.com",
+            user="testuser",
+            key_path="/path/to/key",
+        )
+
+    @pytest.fixture
+    def backup_config(self, tmp_path: Path) -> BackupConfig:
+        return BackupConfig(
+            backup_dir=tmp_path,
+            retention_days=30,
+            schedule_hour=2,
+            schedule_minute=0,
+            timezone="Europe/Berlin",
+            db_root_password="testpass",
+        )
+
+    @pytest.mark.asyncio
+    async def test_creates_compressed_backup(
+        self,
+        ssh_config: SSHConfig,
+        backup_config: BackupConfig,
+    ) -> None:
+        mock_process = AsyncMock()
+        mock_process.returncode = 0
+        mock_process.communicate = AsyncMock(return_value=(b"CREATE TABLE users;", b""))
+
+        with patch("st_andreas.backup.dump.asyncio.create_subprocess_exec") as mock:
+            mock.return_value = mock_process
+            timestamp = datetime(2025, 4, 1, 2, 0, 0)
+
+            result = await create_backup(ssh_config, backup_config, timestamp)
+
+            assert result.name == "admidio_20250401_020000.sql.gz"
+            assert result.exists()
+            with gzip.open(result, "rb") as f:
+                assert f.read() == b"CREATE TABLE users;"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_command_failure(
+        self,
+        ssh_config: SSHConfig,
+        backup_config: BackupConfig,
+    ) -> None:
+        mock_process = AsyncMock()
+        mock_process.returncode = 1
+        mock_process.communicate = AsyncMock(return_value=(b"", b"Connection refused"))
+
+        with patch("st_andreas.backup.dump.asyncio.create_subprocess_exec") as mock:
+            mock.return_value = mock_process
+
+            with pytest.raises(BackupError, match="Connection refused"):
+                await create_backup(ssh_config, backup_config)
+
+    @pytest.mark.asyncio
+    async def test_raises_on_empty_output(
+        self,
+        ssh_config: SSHConfig,
+        backup_config: BackupConfig,
+    ) -> None:
+        mock_process = AsyncMock()
+        mock_process.returncode = 0
+        mock_process.communicate = AsyncMock(return_value=(b"", b""))
+
+        with patch("st_andreas.backup.dump.asyncio.create_subprocess_exec") as mock:
+            mock.return_value = mock_process
+
+            with pytest.raises(BackupError, match="empty output"):
+                await create_backup(ssh_config, backup_config)

--- a/tests/test_backup_retention.py
+++ b/tests/test_backup_retention.py
@@ -1,0 +1,94 @@
+"""Tests for backup retention operations."""
+
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from st_andreas.backup.retention import cleanup_old_backups, find_expired_backups
+
+
+def set_file_mtime(path: Path, days_ago: int) -> None:
+    """Set file modification time to specified days in the past."""
+    target_time = datetime.now() - timedelta(days=days_ago)
+    timestamp = target_time.timestamp()
+    os.utime(path, (timestamp, timestamp))
+
+
+class TestFindExpiredBackups:
+    def test_returns_empty_for_nonexistent_directory(self, tmp_path: Path) -> None:
+        nonexistent = tmp_path / "missing"
+
+        result = find_expired_backups(nonexistent, retention_days=30)
+
+        assert result == []
+
+    def test_returns_empty_when_no_backups_exist(self, tmp_path: Path) -> None:
+        result = find_expired_backups(tmp_path, retention_days=30)
+
+        assert result == []
+
+    def test_returns_empty_when_all_backups_recent(self, tmp_path: Path) -> None:
+        recent_backup = tmp_path / "admidio_20250401_020000.sql.gz"
+        recent_backup.touch()
+
+        result = find_expired_backups(tmp_path, retention_days=30)
+
+        assert result == []
+
+    def test_finds_expired_backups(self, tmp_path: Path) -> None:
+        old_backup = tmp_path / "admidio_20250101_020000.sql.gz"
+        old_backup.touch()
+        set_file_mtime(old_backup, days_ago=45)
+
+        recent_backup = tmp_path / "admidio_20250401_020000.sql.gz"
+        recent_backup.touch()
+
+        result = find_expired_backups(tmp_path, retention_days=30)
+
+        assert len(result) == 1
+        assert result[0] == old_backup
+
+    def test_ignores_non_backup_files(self, tmp_path: Path) -> None:
+        old_file = tmp_path / "random_file.txt"
+        old_file.touch()
+        set_file_mtime(old_file, days_ago=45)
+
+        result = find_expired_backups(tmp_path, retention_days=30)
+
+        assert result == []
+
+
+class TestCleanupOldBackups:
+    def test_deletes_expired_backups(self, tmp_path: Path) -> None:
+        old_backup = tmp_path / "admidio_20250101_020000.sql.gz"
+        old_backup.touch()
+        set_file_mtime(old_backup, days_ago=45)
+
+        deleted = cleanup_old_backups(tmp_path, retention_days=30)
+
+        assert len(deleted) == 1
+        assert not old_backup.exists()
+
+    def test_preserves_recent_backups(self, tmp_path: Path) -> None:
+        recent_backup = tmp_path / "admidio_20250401_020000.sql.gz"
+        recent_backup.touch()
+
+        deleted = cleanup_old_backups(tmp_path, retention_days=30)
+
+        assert deleted == []
+        assert recent_backup.exists()
+
+    def test_returns_list_of_deleted_paths(self, tmp_path: Path) -> None:
+        old_backup_1 = tmp_path / "admidio_20250101_020000.sql.gz"
+        old_backup_1.touch()
+        set_file_mtime(old_backup_1, days_ago=45)
+
+        old_backup_2 = tmp_path / "admidio_20250102_020000.sql.gz"
+        old_backup_2.touch()
+        set_file_mtime(old_backup_2, days_ago=44)
+
+        deleted = cleanup_old_backups(tmp_path, retention_days=30)
+
+        assert len(deleted) == 2
+        assert old_backup_1 in deleted
+        assert old_backup_2 in deleted

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,43 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aioclock"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asyncer" },
+    { name = "croniter" },
+    { name = "fast-depends" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/58/6960028c9528c2b9fcd5fc45beadcc9e705d6009551b86b4331c51478070/aioclock-0.3.0.tar.gz", hash = "sha256:ed992fc3e426c769e59feb0860b4e4a17f126471cc518c1d37dccbfa248d2134", size = 1229364, upload-time = "2024-08-18T18:46:21.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/ed/f3cd1ad1fda9358dd9864fd4beea7350f35b39160b88a7fea8ff0657fed9/aioclock-0.3.0-py3-none-any.whl", hash = "sha256:3cd99b5e06d9a994696205658e574688331c64f017571a0b5410a5a7087be99e", size = 19567, upload-time = "2024-08-18T18:46:19.76Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -23,12 +60,38 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncer"
+version = "0.0.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/4c/62b6044679e08788322bbd0dee5b487a6f7f60bb4e2bd45617ff0d94d1e3/asyncer-0.0.17.tar.gz", hash = "sha256:8a41e185e7ec2ecd583c269d72907a0f9f832e744b6c7474aeb21e349c4becf4", size = 19516, upload-time = "2026-02-21T16:35:54.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/c5/b72735a095b4b3170b34150e89314a40dd0450d0eb6746b331cb664479d1/asyncer-0.0.17-py3-none-any.whl", hash = "sha256:b0055950e094fb84fd8d21611c7e7b6f5715ddcb57c522c058f64c20badd1438", size = 9252, upload-time = "2026-02-21T16:35:55.022Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
 ]
 
 [[package]]
@@ -56,6 +119,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fast-depends"
+version = "3.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/6d/787a21ca8043a8fdb737cf28f645e94a46fc30b44a31de54573299156bad/fast_depends-3.0.8.tar.gz", hash = "sha256:896b16f79a512b6ea1df721b0aa1708a192a06f964be6597e01fcf5412559101", size = 18382, upload-time = "2026-03-02T19:54:28.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/1d/e4843e4eeb65f51447b8c22d200d12d8f94f27c97e77bb7162515cc8d61f/fast_depends-3.0.8-py3-none-any.whl", hash = "sha256:4c52c8a3907bca46d43e70e4364d6d016872d9a3aae4bc0c1c85e72e0a6a21c7", size = 25507, upload-time = "2026-03-02T19:54:27.594Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -274,6 +359,118 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -305,6 +502,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -342,10 +552,20 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "st-andreas"
 version = "1.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aioclock" },
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "pymysql" },
@@ -356,16 +576,19 @@ dev = [
     { name = "dirty-equals" },
     { name = "inline-snapshot" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aioclock", specifier = ">=0.1" },
     { name = "dirty-equals", marker = "extra == 'dev'", specifier = ">=0.7" },
     { name = "inline-snapshot", marker = "extra == 'dev'", specifier = ">=0.10" },
     { name = "openpyxl", specifier = ">=3.0" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pymysql", specifier = ">=1.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
 ]
 provides-extras = ["dev"]
 
@@ -376,6 +599,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add automated daily database backup system for Admidio MariaDB
- Uses AioClock for async scheduling at 02:00 Europe/Berlin
- Backups stored locally with gzip compression and automatic retention cleanup

## Changes

### New backup module (`src/st_andreas/backup/`)
- `config.py` - Configuration with sensible defaults
- `dump.py` - Async mysqldump via SSH with gzip compression
- `retention.py` - Automatic cleanup of old backups
- `scheduler.py` - AioClock-based daily scheduler

### CLI
- New `backup-scheduler` command
- `--once` flag for single backup (testing)

### Tests
- 20 new unit tests covering config, dump, and retention

### Documentation
- Updated README with backup usage
- Updated infrastructure.md with backup/restore procedures

## Usage

```bash
# Run scheduler (daily at 2 AM)
uv run backup-scheduler

# Single backup
uv run backup-scheduler --once

# Systemd service
systemctl --user status st-andreas-backup
```

Closes #6